### PR TITLE
Embedded Thumbnail Option

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -46,6 +46,9 @@ impl YtGUI {
             Message::TogglePlaylist(is_playlist) => {
                 self.is_playlist = is_playlist;
             }
+            Message::ToggleThumbnail(get_thumbnail) =>{
+                self.get_thumbnail = get_thumbnail;
+            }
             Message::SelectedSponsorBlockOption(sponsorblock) => {
                 self.sponsorblock = Some(sponsorblock);
             }
@@ -183,6 +186,11 @@ impl YtGUI {
 
                         args.push(self.config.options.video_format.options());
 
+                        if self.get_thumbnail
+                        {
+                            args.push("--embed-thumbnail")
+                        }
+
                         tracing::debug!("{args:#?}");
                     }
                     DownloadType::Audio => {
@@ -196,6 +204,12 @@ impl YtGUI {
 
                         args.push("--audio-quality");
                         args.push(self.config.options.audio_quality.options());
+
+                        if self.get_thumbnail
+                        {
+                            args.push("--embed-thumbnail")
+                        }
+
                     }
                 }
 
@@ -457,7 +471,10 @@ impl YtGUI {
                 .align_y(iced::Alignment::Center),
                 checkbox(self.is_playlist)
                     .label("Playlist")
-                    .on_toggle(Message::TogglePlaylist),
+                    .on_toggle(Message::TogglePlaylist).spacing(5),
+                checkbox(self.get_thumbnail)
+                    .label("Thumbnail")
+                    .on_toggle(Message::ToggleThumbnail),
             ]
             .spacing(7)
             .align_y(iced::Alignment::Center),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ use crate::media_options::{AudioFormat, AudioQuality, VideoFormat, VideoResoluti
 pub enum Message {
     InputChanged(String),
     TogglePlaylist(bool),
+    ToggleThumbnail(bool),
     SelectedSponsorBlockOption(SponsorBlockOption),
     SelectedVideoFormat(VideoFormat),
     SelectedResolution(VideoResolution),
@@ -146,6 +147,7 @@ impl Config {
 pub struct YtGUI {
     download_link: String,
     is_playlist: bool,
+    get_thumbnail: bool,
     sponsorblock: Option<SponsorBlockOption>,
     config: Config,
 
@@ -175,6 +177,7 @@ impl YtGUI {
         Self {
             download_link: flags.url.clone().unwrap_or_default(),
             is_playlist: Default::default(),
+            get_thumbnail: Default::default(),
             sponsorblock: Default::default(),
             config: flags.config,
 


### PR DESCRIPTION
An embedded thumbnail option has been partially implemented to the application.
Carefully note that the feature for now; is only injected in the required functions  =( thumbnail generating is not recorded in logs, default option changes, etc.)    

The embedded thumbnails works by searching for the best quality of the video then attach it in the downloaded video/audio. 
 
**NOTE: since the majority of the file explorer apps do implement a forced thumbnail generator for preview (not attached to file), the thumbnail videos generated by `ytdlp-gui` may not appear for user, but the implementation is correct and the thumbnail is attached to file.**  